### PR TITLE
chore(build): .env에서 빌드 outDir 읽도록 변경 및 env 파일 무시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Environment files
+.env
+.env.*
+!.env.example

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,36 +1,31 @@
 import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [vue(), vueDevTools()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [vue(), vueDevTools()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
-  },
-  build: {
-    outDir:
-      //'/Users/soohyun/Documents/mozi/src/main/webapp/resources',
-      //'C:/dev/projects/mozi-backend/src/main/webapp/resources',
-      'C:/KB_Fullstack/10_finalProject/mozi-backend/src/main/webapp/resources',
-    //'C:/dev/projects/mozi-backend/src/main/webapp/resources',
-    //'C:/KB-PJT/goal/mozi-backend/src/main/webapp/resources',
-    //"D:/KB_6th/final_project/Mozi/mozi-backend/src/main/webapp/resources",
-    // 'C:/KB_fullstack/final_project/backend/0731/mozi-backend/src/main/webapp/resources',
-    //'C:/KB_Fullstack/accountConnect/mozi_4_backend/src/main/webapp/resources',
-    //'C:/Users/user/Documents/mozi/mozi-bakcend/src/main/webapp/resources',
-  },
+    server: {
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+    build: {
+      outDir: env.VITE_BUILD_OUT_DIR || 'dist',
+    },
+  };
 });


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [ ] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [x] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?

- Vite loadEnv로 VITE_BUILD_OUT_DIR 사용
- .gitignore에 .env, .env.* 추가(단, .env.example은 허용)
- vite.config.js의 하드코딩된 outDir 제거


### 왜 이 변경이 필요한가요?
- [x] build 경로 직접 설정 시 작업 환경 별 build 실패 문제


> **Note**  
## ✅ 체크리스트
- [x] 빌드 정상 작동 여부

```bash
